### PR TITLE
docs: add CLAUDE.md and PRD for tkodev-web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,246 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this repo is
+
+A Next.js (App Router) implementation of [tko.dev](https://tko.dev/), Tony Ko's personal
+portfolio website. The site is a polished, cinematic portfolio that presents Tony's career
+as a Staff Software Engineer — covering professional work, clients, employment history,
+photography shots, and personal design disciplines (industrial design, architecture).
+
+Specs live in `prd/` (see `prd/PRD.md`); application code lives in `src/app/`, with
+shared components in `src/components/`, data in `src/constants/`, state in `src/stores/`,
+and CSS tokens in `src/themes/`.
+
+For developer-facing setup (scripts, directory tree, route map), see [`README.md`](./README.md).
+
+## Repository layout
+
+```
+.
+├── CLAUDE.md              # This file
+├── prd/
+│   ├── PRD.md             # Top-level product requirements document
+│   └── pages/             # One spec per route
+│       ├── home.md                # /
+│       ├── archive.md             # /archive
+│       ├── profile.md             # /profile
+│       ├── shots.md               # /shots
+│       └── works/
+│           ├── index.md           # /works
+│           └── project.md         # /works/[projectIdPath]
+└── src/
+    ├── app/               # Next.js App Router pages
+    │   ├── layout.tsx     # Root layout (providers, fonts, metadata)
+    │   ├── page.tsx       # / — home
+    │   ├── loading.tsx    # Next.js streaming loading UI
+    │   ├── archive/       # /archive
+    │   ├── loading/       # /loading (lifecycle loading screen route)
+    │   ├── profile/       # /profile
+    │   ├── shots/         # /shots
+    │   └── works/         # /works and /works/[projectIdPath]
+    ├── components/
+    │   ├── atoms/         # Primitive UI elements
+    │   ├── molecules/     # Compound components
+    │   ├── organisms/     # Page-section compositions
+    │   ├── sections/      # Layout shells (header, footer, main, overlay, base)
+    │   └── templates/     # Full-page layout wrappers
+    ├── constants/         # Static data (clients, jobs, projects, profiles, shots, media)
+    ├── fonts/             # next/font loader modules
+    ├── hooks/             # React hooks (audio, filter, theme)
+    ├── providers/         # Context providers (BGM, lifecycle, theme)
+    ├── stores/            # Zustand stores (bgm, lifecycle)
+    ├── themes/            # CSS token files imported in root layout
+    ├── types/             # TypeScript types for domain models
+    └── utils/             # Utility functions (date, string, theme, timer)
+```
+
+`prd/PRD.md` is the top-level document. Each file in `prd/pages/` fully describes one
+route. The file tree under `prd/pages/` mirrors the final URL structure.
+
+## How the information architecture works
+
+The site is a **cinematic personal portfolio** with a lifecycle-driven intro experience:
+
+- `/` — home intro (animated welcome, entry point to the portfolio).
+- `/profile` — career overview: bio, employment history, client logo cloud.
+- `/works` — filterable project gallery (featured and all projects).
+- `/works/[projectIdPath]` — individual project deep-dive (frames, media, team, skills).
+- `/shots` — photography / creative shot gallery.
+- `/archive` — archived / legacy projects and older work.
+- `/loading` — lifecycle loading screen shown during the initial site experience.
+
+The site has a single persistent `Layout` (header + footer + overlay) wrapping all pages.
+There are no shared sub-nav layouts; each page is self-contained within that shell.
+
+## Working conventions
+
+### Data management
+
+All site content is stored as typed constants in `src/constants/`:
+
+- `client.ts` — `clientEntries` and `clientIds`: companies/clients Tony has worked with.
+- `job.ts` — `jobEntries`: chronological employment history with skills.
+- `project.ts` — `projectEntries` and `projectIds`: portfolio projects with media, frames,
+  team members, skills, and featured flag.
+- `profile.ts` — `profileEntries`: collaborators referenced in projects.
+- `shots.ts` — shot gallery entries.
+- `media.ts` — shared media entries.
+- `theme.ts` — Tailwind theme constants (screens, colors, typography, utilities, animations).
+- `date.ts` — timezone constants (`appTimeZone`).
+
+When adding or updating content, edit the relevant constant file. Do **not** create
+additional data sources or fetch from external APIs unless explicitly asked.
+
+Dates are always stored via `fromZonedTime(isoString, appTimeZone)` from `date-fns-tz`.
+Never use `new Date()` directly for project/job dates.
+
+### Component conventions
+
+Components follow an **Atomic Design hierarchy**:
+
+- `atoms/` — primitives with no dependencies on other components (Button, Icon, Logo,
+  Frame, Media, Video, Hypertext, etc.). Use CVA for variants.
+- `molecules/` — composites of atoms (Nav, Filter, Section, Dialog, Table).
+- `organisms/` — full page-section implementations (`section-home`, `section-projects`,
+  `section-project`, `section-profile`, `section-jobs`, `section-clients`, etc.).
+- `sections/` — layout shells (`Base`, `Header`, `Footer`, `Main`, `Overlay`).
+- `templates/` — full-page wrappers (`Layout`).
+
+Rules:
+- Use CVA (`class-variance-authority`) for all visual variant management — never ad-hoc
+  `className` overrides at the call site.
+- Use `cn()` + `cva()` from `src/utils/theme.ts` (clsx + tailwind-merge) for all
+  className composition.
+- Expose `asChild` via Radix `Slot` when a component needs to delegate rendering to its
+  child (e.g. `<Button asChild><Link …>`).
+- Keep layout utilities (`w-full`, `mt-4`, etc.) at the call site via `className`;
+  keep visual styles inside the CVA definition.
+- New primitives go in `atoms/`; compositions stay in `molecules/` or `organisms/`.
+
+### Theming
+
+- `next-themes` handles light/dark/system detection. `ThemeProvider` is in
+  `src/providers/theme.tsx`. Always set `defaultTheme="system"` and `enableSystem`.
+- Add `suppressHydrationWarning` to `<html>` and `<body>` to avoid hydration mismatches.
+- Theme-aware components must `useEffect` + `useState(mounted)` and return a placeholder
+  until mounted — otherwise icons and states will SSR incorrectly.
+- CSS token files are imported in `src/app/layout.tsx` in order:
+  `theme.css` → `theme-colors.css` → `theme-utils.css`.
+- The Tailwind theme config is exported from `src/themes/theme.ts` and consumed by
+  `next.config.ts` / postcss.
+
+### Semantic colour tokens
+
+- Never use raw hex values or non-semantic Tailwind color utilities in components.
+  Use semantic tokens: `text-foreground`, `bg-background`, `bg-primary`,
+  `text-primary-foreground`, `text-muted-foreground`, `bg-card`, `bg-accent`, etc.
+- Pair every background token with its matching foreground:
+  `bg-primary → text-primary-foreground`, `bg-card → text-card-foreground`.
+- Dark-mode overrides are handled via CSS custom properties — components do not need
+  per-component dark overrides if semantic tokens are used correctly.
+
+### Global state
+
+Two Zustand stores manage sitewide UI state:
+
+**`stores/lifecycle.ts`** — `useLifecycleState`:
+- Tracks the site's lifecycle phase: `initial → intro → ready → loading → error`.
+- `LifecycleProvider` (`providers/lifecycle.tsx`) drives the intro animation sequence.
+- Do not add new lifecycle phases without updating `LifecycleProvider` and `section-loading`.
+
+**`stores/bgm.ts`** — `useBgmStore`:
+- Tracks background music state: `bgmConfirm`, `bgmState` (`playing/paused/stopped`),
+  and raw audio data (buffered, time, duration, volume, etc.).
+- `BgmProvider` (`providers/bgm.tsx`) manages the audio element.
+- BGM consent (`bgmConfirm`) must be set to `true` before audio can play — never
+  auto-play without user confirmation.
+
+Keep `next-themes` as the single source of truth for theme — do not duplicate theme
+state in Zustand.
+
+Use `pnpm` (not npm or yarn) for all package operations in this repo.
+
+### Fonts
+
+Two fonts are loaded via `next/font/local` and applied on `<body>`:
+
+- **Alliance No.2** (`--font-alliance-no2`) — used for display headings and branded text.
+- **Geist Sans** (`--font-geist-sans`) — used for body text (`font-geist-sans` Tailwind
+  class is the default body font).
+
+Additional font modules exist (`alliance-no1`, `carbon`, `industry`, `inter`) but may
+not be active. Only activate via the root layout font variable if required.
+
+### Page transitions and motion
+
+- `next-transition-router` handles page-level transitions. Do not use `next/link` where
+  the router's `<Link>` is expected — check existing usage before adding navigation.
+- `motion` (Framer Motion) is used for component-level animations. Use existing
+  animation keyframes defined in `src/themes/theme.ts` (`fade-in`, `fade-out`,
+  `slide-down`, `slide-up`, `accordion-*`) before defining new ones.
+- Custom cursor is implemented via `react-animated-cursor` in the `Cursor` atom.
+
+### Adding a new page
+
+1. Decide where it belongs in the IA. Works-related pages go under `/works`; standalone
+   pages are siblings of `/profile`, `/shots`, `/archive`.
+2. Create `src/app/<path>/page.tsx` following the existing page structure (import the
+   relevant organism section, wrap in `<Main>`).
+3. Create `prd/pages/<path>.md` following the existing section structure.
+4. Add the route to the Route map table in `prd/PRD.md` §2.
+5. Update the header nav in `src/components/sections/header.tsx` if the page should
+   appear in global navigation.
+
+### Removing or renaming a page
+
+- Remove the `app/` directory, the `prd/pages/` file, and any nav references.
+- Use Grep to find all references to the route before deleting.
+
+## Things to avoid
+
+- Don't let the implementation drift from the PRD. When behaviour or IA changes, update
+  both the relevant `prd/pages/*.md` spec and the matching `src/app/` code in the same
+  change.
+- Don't use raw `new Date()` for project/job dates — always use `fromZonedTime` with
+  `appTimeZone`.
+- Don't add data to component files. All content lives in `src/constants/`.
+- Don't auto-play BGM. Always require `bgmConfirm` to be set before playing.
+- Don't use non-semantic colour values in JSX (`text-teal-500`, raw hex `#fff`). Use
+  semantic tokens only.
+- Don't create new Zustand stores for ephemeral UI state that belongs in local `useState`.
+- Don't touch settings or hooks without being asked.
+
+## Git workflow
+
+- Feature work happens on the branch specified in the session brief.
+- Create new commits rather than amending. Use HEREDOC commit messages.
+- Never force-push or skip hooks without explicit permission.
+- Do not open a pull request unless explicitly asked.
+- Do not sign commits or PRs as Claude, and do not include `claude.ai/code` session
+  links, `Co-Authored-By: Claude` trailers, or any other "Generated with Claude Code"
+  markers in commit messages or PR bodies.
+
+### Conventional commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for every commit subject:
+  `<type>(<optional scope>): <imperative summary>`
+- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+  `ci`, `chore`, `revert`.
+- Pick a scope matching the page or area (`home`, `works`, `profile`, `shots`, `archive`,
+  `prd`, `constants`, `theme`, `bgm`, `lifecycle`, etc.) when obvious; omit when global.
+- Keep the subject under ~72 characters, lowercase, no trailing period; explain the *why*
+  in the body if the diff alone doesn't.
+- Use `!` (e.g. `feat(works)!: …`) and a `BREAKING CHANGE:` footer for changes that
+  move URLs, rename routes, or alter documented behavior.
+
+### Branch naming
+
+- Branches follow `<type>/<short-kebab-summary>` using the same type vocabulary as
+  commits — e.g. `feat/works-filter`, `fix/bgm-consent`, `docs/prd-profile`,
+  `refactor/lifecycle-intro`.
+- Session-managed Claude branches keep the `claude/<slug>` prefix given in the session
+  brief; treat the slug as the conventional summary and don't rename it.
+- Keep slugs short (≤40 chars), lowercase, hyphen-separated, referencing the affected
+  area rather than a ticket number.

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -1,0 +1,240 @@
+# PRD — tko.dev
+
+Product requirements for [tko.dev](https://tko.dev/), Tony Ko's personal portfolio website.
+
+---
+
+## 1. Product overview
+
+### 1.1 Purpose
+
+tko.dev is a **cinematic personal portfolio** for Tony Ko — a Staff Software Engineer
+with 25+ years of experience spanning web, mobile, browser extensions, embedded systems,
+industrial design, and architecture. The site communicates Tony's breadth and depth to
+prospective clients, employers, and collaborators, while expressing his personal aesthetic
+through an immersive, design-forward experience.
+
+### 1.2 Audience
+
+- **Prospective employers and clients** — evaluating Tony's technical capabilities,
+  project history, and leadership track record.
+- **Collaborators and peers** — exploring shared work and referenced team members.
+- **Design community** — engaging with the visual quality of the portfolio itself.
+
+### 1.3 Tone and aesthetic
+
+- **Cinematic and intentional.** Transitions, animations, and the BGM system create an
+  immersive first impression. The intro lifecycle is part of the product experience.
+- **Precise and confident.** Copy is terse and factual. Descriptions are written in the
+  first person, past tense, reflecting real outcomes — not aspirational marketing language.
+- **Dark-mode-forward.** The site is designed light/dark-aware with semantic tokens, but
+  the default aesthetic leans dark. Every page must look polished in both modes.
+
+---
+
+## 2. Information architecture
+
+### 2.1 Route map
+
+| Route                       | Page               | Nav label  | Notes                              |
+|-----------------------------|--------------------|------------|------------------------------------|
+| `/`                         | Home               | —          | Intro / animated entry point       |
+| `/profile`                  | Profile            | Profile    | Bio, employment, clients           |
+| `/works`                    | Works              | Works      | Filterable project gallery         |
+| `/works/[projectIdPath]`    | Project Detail     | —          | Individual project deep-dive       |
+| `/shots`                    | Shots              | Shots      | Photography / creative gallery     |
+| `/archive`                  | Archive            | Archive    | Legacy / older work                |
+| `/loading`                  | Loading Screen     | —          | Lifecycle intro animation route    |
+
+### 2.2 Navigation
+
+The global `Header` component contains the primary nav. Nav items link to:
+`/profile`, `/works`, `/shots`, `/archive`.
+
+The `/` home page and `/loading` screen are not in the nav. The `/works/[projectIdPath]`
+detail page is accessed only from `/works`.
+
+### 2.3 Layout shell
+
+All pages share one persistent `Layout` wrapper:
+
+```
+Layout
+├── Base          # Background visual layer (animated bg)
+├── Header        # Global nav + logo + theme toggle + BGM control
+├── {page}        # Page-specific content wrapped in <Main>
+├── Footer        # Copyright, links
+└── Overlay       # Lifecycle overlay (loading/intro state)
+```
+
+There are no shared sub-nav layouts. Each page is self-contained within the shell.
+
+---
+
+## 3. Lifecycle and BGM system
+
+### 3.1 Lifecycle states
+
+The site has a five-state lifecycle managed by `useLifecycleState` (Zustand):
+
+| State     | Description                                                   |
+|-----------|---------------------------------------------------------------|
+| `initial` | App has mounted; before intro begins                          |
+| `intro`   | Intro animation is playing (`/loading` screen active)         |
+| `ready`   | Intro complete; site is fully interactive                     |
+| `loading` | A page transition or data load is in progress                 |
+| `error`   | An unrecoverable error has occurred                           |
+
+The `LifecycleProvider` drives state transitions. `SectionLoading` and the `Overlay`
+component render based on lifecycle state.
+
+### 3.2 BGM system
+
+Background music enhances the cinematic experience. Rules:
+
+- BGM must never auto-play. `bgmConfirm` must be set to `true` by explicit user action
+  before any audio plays.
+- The `BgmProvider` manages the audio element. The `Header` exposes the BGM control.
+- BGM state: `playing`, `paused`, `stopped`. Default: `paused`.
+- Current track: `an-empty-bus-justin-marshall-elias-main-version-36442-03-56.mp3`
+  (served from `/audio/`).
+
+---
+
+## 4. Design system
+
+### 4.1 Fonts
+
+| Variable              | Font family      | Usage                          |
+|-----------------------|------------------|--------------------------------|
+| `--font-alliance-no2` | Alliance No.2    | Display headings, brand text   |
+| `--font-geist-sans`   | Geist Sans       | Body text (default)            |
+
+### 4.2 Breakpoints
+
+| Token | Value  |
+|-------|--------|
+| `xs`  | 480px  |
+| `sm`  | 640px  |
+| `md`  | 768px  |
+| `lg`  | 1024px |
+| `xl`  | 1280px |
+| `2xl` | 1440px |
+| `3xl` | 1536px |
+| `4xl` | 1920px |
+
+### 4.3 Semantic colour tokens
+
+All components must use semantic tokens — never raw hex or brand-named Tailwind utilities.
+
+| Token                      | Usage                        |
+|----------------------------|------------------------------|
+| `bg-background`            | Page background              |
+| `text-foreground`          | Primary text                 |
+| `bg-primary`               | Primary action background    |
+| `text-primary-foreground`  | Text on primary              |
+| `bg-secondary`             | Secondary elements           |
+| `text-secondary-foreground`| Text on secondary            |
+| `bg-muted`                 | Muted / subdued backgrounds  |
+| `text-muted-foreground`    | Muted / caption text         |
+| `bg-card`                  | Card surfaces                |
+| `text-card-foreground`     | Text on card                 |
+| `bg-accent`                | Accent highlights            |
+| `text-accent-foreground`   | Text on accent               |
+
+### 4.4 Typography scale
+
+| Class | Size  | Usage             |
+|-------|-------|-------------------|
+| `h1`  | 72px  | Hero headings     |
+| `h2`  | 56px  | Section headings  |
+| `h3`  | 32px  | Sub-section heads |
+| `h4`  | 28px  | Card titles       |
+| `h5`  | 24px  | Labels            |
+| `h6`  | 20px  | Small labels      |
+| `lg`  | 18px  | Lead body text    |
+| `base`| 16px  | Body text         |
+| `sm`  | 14px  | Captions, meta    |
+
+### 4.5 Animation tokens
+
+Defined in `src/themes/theme.ts` and available as Tailwind animation utilities:
+
+| Token          | Duration | Easing   | Usage                          |
+|----------------|----------|----------|--------------------------------|
+| `fade-in`      | 1.5s     | ease-out | Section entrance               |
+| `fade-out`     | 1.5s     | ease-out | Section exit                   |
+| `slide-down`   | 1.5s     | ease-out | Header / nav slide-in          |
+| `slide-up`     | 1.5s     | ease-out | Content slide-in from bottom   |
+| `accordion-down` | 0.2s  | ease-out | Accordion expand               |
+| `accordion-up` | 0.2s     | ease-out | Accordion collapse             |
+
+---
+
+## 5. Data model
+
+### 5.1 Projects (`src/constants/project.ts`)
+
+Each `ProjectEntry` has:
+
+| Field        | Type            | Description                                      |
+|--------------|-----------------|--------------------------------------------------|
+| `id`         | `ProjectId`     | Unique camelCase identifier                      |
+| `roles`      | `string[]`      | `'development'` and/or `'design'`                |
+| `media`      | `MediaEntry[]`  | Gallery images/videos                            |
+| `frames`     | `FrameEntry[]`  | Device-framed screenshots (desktop/mobile)       |
+| `title`      | `string`        | Display title                                    |
+| `intro`      | `string`        | One-paragraph summary (used in cards)            |
+| `desc`       | `string`        | Full markdown description (used in detail view)  |
+| `clientId`   | `ClientId`      | Client/employer reference                        |
+| `profileIds` | `ProfileId[]`   | Collaborators on the project                     |
+| `startDate`  | `Date`          | `fromZonedTime(isoString, appTimeZone)`          |
+| `endDate`    | `Date?`         | Undefined if ongoing                             |
+| `skills`     | `string[]`      | Tech/skill tags                                  |
+| `isFeatured` | `boolean?`      | Show in featured/highlighted view                |
+
+The `projectIds` array controls display order in the works gallery.
+
+### 5.2 Clients (`src/constants/client.ts`)
+
+Each `ClientEntry` has: `id`, `name`, `href`, `baseSrc`, `lightSrc`, `darkSrc`
+(logo image paths for neutral/light/dark themes).
+
+The `clientIds` array controls display order in the client logo cloud.
+
+### 5.3 Jobs (`src/constants/job.ts`)
+
+Each `JobEntry` has: `id`, `companyId`, `companyName`, `title`, `location`,
+`startDate`, `endDate?`, `skills[]`.
+
+Jobs are listed chronologically (newest first) in the profile page.
+
+### 5.4 Profiles (`src/constants/profile.ts`)
+
+Each `ProfileEntry` has: `id`, `name`, `title`, `linkedin`, `github`, `email`, `phone`.
+Profiles represent collaborators credited on projects.
+
+---
+
+## 6. Page-level requirements index
+
+- [Home](pages/home.md) — `/`
+- [Profile](pages/profile.md) — `/profile`
+- [Works](pages/works/index.md) — `/works`
+- [Project Detail](pages/works/project.md) — `/works/[projectIdPath]`
+- [Shots](pages/shots.md) — `/shots`
+- [Archive](pages/archive.md) — `/archive`
+
+---
+
+## 7. Non-functional requirements
+
+- **Performance**: The site targets fast LCP on desktop and mobile. Images are served
+  via `next/image` with explicit width/height. Videos autoplay muted for frame previews.
+- **Accessibility**: Semantic HTML, keyboard navigation, and appropriate `alt` text on
+  all media entries are required. AODA/WCAG 2.0 AA is the baseline.
+- **SEO**: Root layout exports full `Metadata` (title, description, Open Graph, Twitter
+  card) targeting `tko.dev`. Per-page metadata should override where relevant.
+- **Theming**: All pages must render correctly in `light`, `dark`, and `system` modes.
+  `suppressHydrationWarning` is set on `<html>` and `<body>`.
+- **Package manager**: `pnpm` only. Node ≥ 24 required.

--- a/prd/pages/archive.md
+++ b/prd/pages/archive.md
@@ -1,0 +1,39 @@
+# Page spec — Archive (`/archive`)
+
+## Purpose
+
+A collection of older, legacy, or supplementary work not featured in the primary
+Works gallery. Preserves historical work and early career artifacts.
+
+## Primary audience
+
+Visitors who want the full picture of Tony's background, including early-career work.
+
+## Key messages
+
+- Tony's roots go back to Web 1.0 era design, architecture school, and early
+  self-taught software engineering — this page shows that full arc.
+
+## Content sections
+
+### Archive gallery (`SectionArchive`)
+
+- Sourced from the subset of `projectEntries` not included in the primary
+  `projectIds` display, or an explicit archive list in `constants/`.
+- Each item shows title, date range, and a brief intro.
+
+## CTAs
+
+- None mandatory. Individual items may link to `/works/[projectIdPath]` if the
+  project also exists in the works gallery.
+
+## Functional requirements
+
+- Archive data sourced from `src/constants/` — no hardcoded content.
+- Items may not have media; render gracefully when `media` and `frames` are empty.
+
+## Acceptance criteria
+
+- [ ] Archive renders all items without error when media arrays are empty.
+- [ ] Page is responsive across xs–4xl breakpoints.
+- [ ] Page renders correctly in light and dark modes.

--- a/prd/pages/home.md
+++ b/prd/pages/home.md
@@ -1,0 +1,41 @@
+# Page spec — Home (`/`)
+
+## Purpose
+
+The animated entry point for the portfolio. Establishes tone and aesthetic before
+the visitor explores the rest of the site. Does not appear in the global nav.
+
+## Primary audience
+
+First-time visitors arriving directly at `tko.dev`.
+
+## Key messages
+
+- Tony Ko is a Staff Software Engineer with a distinctive, design-forward perspective.
+- The site itself is a portfolio artifact — its craft signals his standards.
+
+## Content sections
+
+### Hero / Welcome
+
+- Animated welcome text via `SectionWelcome` / `SectionHome`.
+- Lifecycle-aware: renders after the `intro` state completes.
+- No scrolling content; the home is a single-screen intro.
+
+## CTAs
+
+- Implicit navigation: the header nav (Profile, Works, Shots, Archive) is the primary
+  forward path after the intro.
+
+## Functional requirements
+
+- `SectionHome` is rendered inside `<Main>` with `id="intro"`.
+- The page must be lifecycle-aware — content should not flash before the intro
+  animation completes.
+- No data fetching; no dynamic content.
+
+## Acceptance criteria
+
+- [ ] Home renders without content flash before the lifecycle `ready` state.
+- [ ] Header nav is accessible from the home page in all lifecycle states.
+- [ ] Page is responsive and visually polished in light and dark modes.

--- a/prd/pages/profile.md
+++ b/prd/pages/profile.md
@@ -1,0 +1,77 @@
+# Page spec — Profile (`/profile`)
+
+## Purpose
+
+Presents Tony Ko's professional identity in full: bio, career timeline, and the
+breadth of clients he has served. Primary destination for recruiters and potential
+clients.
+
+## Primary audience
+
+Recruiters, hiring managers, prospective clients evaluating Tony for contract or
+full-time engagement.
+
+## Key messages
+
+- Staff-level engineer with 25+ years of experience across web, mobile, extensions,
+  and embedded systems.
+- Track record with top North American brands: Aeroplan, Air Miles, Loblaws,
+  Peoples Group, Toyota, and more.
+- Combines technical leadership with design background (OCAD University, interior
+  architecture, industrial design).
+
+## Content sections
+
+### Profile / Bio (`SectionProfile`)
+
+- Avatar / headshot.
+- Name: Tony Ko.
+- Title: Staff Software Engineer.
+- Contact: `tony@tko.dev`, LinkedIn, GitHub.
+- Resume download: `/files/tony-ko-resume-2026.pdf`.
+- Short bio drawn from the `profileEntries.tony` data and the `pagedata.description`
+  in `src/app/layout.tsx`.
+
+### Employment history (`SectionJobs`)
+
+Sourced from `src/constants/job.ts`. Display in reverse-chronological order:
+
+| Title                     | Company                             | Period                   |
+|---------------------------|-------------------------------------|--------------------------|
+| Senior Software Engineer  | Badal.io (current, ongoing)         | Dec 2024 – present       |
+| Staff Software Engineer   | Badal.io                            | May 2023 – Nov 2024      |
+| Staff Software Engineer   | Quantum Mob                         | Nov 2022 – May 2023      |
+| Senior Software Engineer  | Quantum Mob                         | Nov 2021 – Oct 2022      |
+| Software Engineer II      | Quantum Mob                         | Nov 2020 – Oct 2021      |
+| Software Engineer I       | Quantum Mob                         | Nov 2019 – Oct 2020      |
+| Intermediate FE Developer | Brandfire Marketing Group Inc.      | Apr 2017 – Nov 2019      |
+| Interior Designer         | Ko's Interior Design & Construction | Jul 2013 – Sep 2016      |
+
+Each entry shows company, title, location, date range, and skill tags.
+
+### Client logo cloud (`SectionClients`)
+
+Sourced from `src/constants/client.ts`, ordered by `clientIds`. Logos are
+theme-aware (`baseSrc` / `lightSrc` / `darkSrc`). Display the 15 client logos in
+the defined order.
+
+## CTAs
+
+- Download resume: `/files/tony-ko-resume-2026.pdf`.
+- Contact: `tony@tko.dev`.
+- LinkedIn: `https://www.linkedin.com/in/tkodev`.
+
+## Functional requirements
+
+- All data sourced from `src/constants/` — no hardcoded copy in the component.
+- Resume link must open the PDF in a new tab.
+- Client logos must switch between light/dark variants based on active theme.
+- Employment dates are rendered via `date-fns` relative formatting where appropriate.
+
+## Acceptance criteria
+
+- [ ] All job entries render from `jobEntries` in reverse-chronological order.
+- [ ] All client logos from `clientIds` render with correct light/dark variants.
+- [ ] Resume PDF link opens in a new tab.
+- [ ] Page is responsive across xs–4xl breakpoints.
+- [ ] Page renders correctly in light and dark modes.

--- a/prd/pages/shots.md
+++ b/prd/pages/shots.md
@@ -1,0 +1,44 @@
+# Page spec — Shots (`/shots`)
+
+## Purpose
+
+A photography and creative media gallery. Demonstrates Tony's visual sensibility
+beyond software — an extension of his design background.
+
+## Primary audience
+
+Anyone curious about Tony's creative perspective and visual interests beyond code.
+
+## Key messages
+
+- Technical precision and design sensibility carry across disciplines.
+- Photography is presented with the same care as the portfolio work.
+
+## Content sections
+
+### Shot gallery (`SectionShots`)
+
+Sourced from `src/constants/shots.ts`. Displays all shot entries in a grid or
+masonry layout. Each shot shows:
+- Image or video media.
+- Caption / alt text.
+
+Clicking a shot opens the `DialogMedia` lightbox for full-size viewing.
+
+## CTAs
+
+- Shot click → `DialogMedia` lightbox.
+
+## Functional requirements
+
+- All shot data sourced from `src/constants/shots.ts` — no hardcoded media in
+  the component.
+- The lightbox must be keyboard-accessible and closable via Escape.
+- Images are served via `next/image` with explicit dimensions from the shot entry.
+
+## Acceptance criteria
+
+- [ ] All shots from `shots.ts` render in the gallery.
+- [ ] Clicking a shot opens the `DialogMedia` lightbox.
+- [ ] Page is responsive across xs–4xl breakpoints.
+- [ ] Page renders correctly in light and dark modes.

--- a/prd/pages/works/index.md
+++ b/prd/pages/works/index.md
@@ -1,0 +1,62 @@
+# Page spec — Works (`/works`)
+
+## Purpose
+
+A filterable gallery of portfolio projects. Visitors can browse all projects or
+filter by role (development, design) and featured status. Each project card links
+to its detail page.
+
+## Primary audience
+
+Employers and clients evaluating Tony's project breadth and technical range.
+
+## Key messages
+
+- Tony has shipped across web, mobile, browser extensions, embedded systems, and
+  physical design — 27 projects spanning 2000 to present.
+- Featured projects represent the highest-impact or most technically complex work.
+- The gallery is filterable and browsable without leaving the page.
+
+## Content sections
+
+### Filter bar (`Filter` molecule)
+
+- Filter by role: `all`, `development`, `design`.
+- Filter by featured: `all`, `featured`.
+- Filters are applied client-side; no route change.
+
+### Project grid (`SectionProjects`)
+
+Sourced from `src/constants/project.ts`, ordered by `projectIds`. Each card shows:
+
+- Project title.
+- Client name (from `clientEntries[project.clientId]`).
+- Intro excerpt.
+- Primary media thumbnail (first `media` entry, if any).
+- Role tags.
+- Start / end date range.
+- Featured badge if `isFeatured: true`.
+
+Each card links to `/works/[projectId]`.
+
+## CTAs
+
+- Project card click → `/works/[projectIdPath]`.
+
+## Functional requirements
+
+- Projects are filtered client-side using `useFilter` hook (`src/hooks/filter.ts`).
+- The full `projectIds` order from `constants/project.ts` defines display order
+  within each filter result.
+- Empty filter states (if a filter combination yields no results) must be handled
+  gracefully.
+- No pagination; all projects render in a single scrollable view.
+
+## Acceptance criteria
+
+- [ ] All 27 projects from `projectIds` render when filter is `all`.
+- [ ] Role filter (`development` / `design`) correctly shows only matching projects.
+- [ ] Featured filter correctly shows only projects with `isFeatured: true`.
+- [ ] Each card links to the correct `/works/[projectId]` detail page.
+- [ ] Page is responsive across xs–4xl breakpoints.
+- [ ] Page renders correctly in light and dark modes.

--- a/prd/pages/works/project.md
+++ b/prd/pages/works/project.md
@@ -1,0 +1,81 @@
+# Page spec — Project Detail (`/works/[projectIdPath]`)
+
+## Purpose
+
+Deep-dive view for a single portfolio project. Shows framed screenshots, gallery
+media, full description, team members, skills, and client context.
+
+## Primary audience
+
+Employers and clients who clicked through from the Works gallery to evaluate a
+specific project in detail.
+
+## Key messages
+
+- Concrete outcomes, specific technologies, and real team context — not generic claims.
+- Framed screenshots and gallery media demonstrate the visual quality of the work.
+- Collaborators are credited and linked.
+
+## Content sections
+
+### Project header (`SectionProject`)
+
+- Title.
+- Client name + link (from `clientEntries[project.clientId]`).
+- Date range: `startDate` → `endDate` (or "Present" if ongoing).
+- Role tags: `development`, `design`.
+- Skills tag cloud.
+
+### Frames (`SectionFrames`)
+
+Device-framed media (`project.frames`). Each frame entry has:
+- `frameId`: `'desktop'` or `'mobile'` — determines the device frame rendered.
+- `type`: `'image'` or `'video'`.
+- `src`, `width`, `height`, `alt`.
+
+Desktop frames show at full width. Mobile frames show in a phone chrome.
+
+### Gallery (`SectionMedia`)
+
+All `project.media` entries displayed in a scrollable gallery. Opens a `DialogMedia`
+lightbox on click for full-size viewing.
+
+### Full description (`SectionProject`)
+
+Rendered via `Markdown` atom. Supports bold, headings, and paragraph formatting
+from the `project.desc` field.
+
+### Team (`SectionProfile`)
+
+All `project.profileIds` rendered as collaborator credits. Each shows:
+- Name, title, LinkedIn link.
+
+### Back navigation
+
+Link back to `/works`.
+
+## CTAs
+
+- Client name → external client/company URL (new tab).
+- Collaborator LinkedIn links → external (new tab).
+- Back to Works → `/works`.
+
+## Functional requirements
+
+- `projectIdPath` is the camelCase project ID (e.g., `loblawsPerfectExperience`).
+- The page reads from `projectEntries[projectIdPath]` in `constants/project.ts`.
+- If `projectIdPath` does not match a known ID, render a 404.
+- Media dialog (`DialogMedia`) must be keyboard-accessible and closable via Escape.
+- Videos in frames autoplay muted and loop for ambient preview.
+- The `desc` field may contain markdown — always render via the `Markdown` atom.
+
+## Acceptance criteria
+
+- [ ] All `projectIds` resolve to a valid detail page (no broken routes).
+- [ ] Frames render with correct device chrome (desktop / mobile) per `frameId`.
+- [ ] Gallery media opens in the `DialogMedia` lightbox on click.
+- [ ] Markdown in `desc` renders correctly (bold, paragraphs, headings).
+- [ ] Team section shows all collaborators from `profileIds` with LinkedIn links.
+- [ ] Client link opens in a new tab.
+- [ ] Page renders correctly in light and dark modes.
+- [ ] Page is responsive across xs–4xl breakpoints.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with Claude Code guidance: repo layout, IA, component conventions, lifecycle/BGM system, data model, theming, semantic tokens, git workflow
- Adds `prd/PRD.md` with top-level product requirements: route map, design system, data model, non-functional requirements
- Adds per-page specs in `prd/pages/` for all six routes: home, profile, works (index + project detail), shots, archive

## Test plan

- [ ] Review `CLAUDE.md` for accuracy against current source code
- [ ] Review `prd/PRD.md` route map and data model against `src/constants/`
- [ ] Review per-page specs for completeness