### PR TITLE
fix(contact): vertically center table value column cells

### DIFF
--- a/components/organisms/section-contact.tsx
+++ b/components/organisms/section-contact.tsx
@@ -37,6 +37,7 @@ const styles = {
   tableTitleHead: cva('w-[30%]'),
   tableHead: cva('w-[30%]'),
   tableCellChannel: cva('flex items-center gap-4'),
+  tableCellValue: cva('align-middle'),
 
   note: cva('text-muted-foreground text-sm')
 }
@@ -135,7 +136,7 @@ const SectionContact = forwardRef<SectionContactRef, SectionContactProps>((props
                 <Icon icon={icon} size="xs" />
                 {label}
               </TableCell>
-              <TableCell>
+              <TableCell className={cn(styles.tableCellValue())}>
                 <Link href={href(tony)} target={external ? '_blank' : undefined}>
                   {value}
                 </Link>


### PR DESCRIPTION
## Summary
- Adds `align-middle` override to the value column `TableCell` in `section-contact`
- Matches the vertical alignment of the channel column (which uses `flex items-center`)
- Scoped to the contact section only — global `TableCell` default (`align-top`) is unchanged