### PR TITLE
feat(cursor,footer,contact): cursor enhancements, footer license, contact buttons

### DIFF
--- a/components/atoms/cursor.tsx
+++ b/components/atoms/cursor.tsx
@@ -6,16 +6,40 @@ import { cn, cva } from '@/utils/theme'
 
 const styles = {
   ring: cva([
-    'pointer-events-none fixed top-0 left-0 z-[9999]',
+    'border-foreground/30 pointer-events-none fixed top-0 left-0 z-9999 border',
     'flex h-[72px] w-[72px] items-center justify-center',
     'rounded-full opacity-0',
-    '[border:1px_solid_hsl(var(--foreground)/0.30)]',
-    '[mix-blend-mode:exclusion]'
+    'mix-blend-exclusion'
   ]),
-  icon: cva(['absolute [color:hsl(var(--foreground)/0.60)]', 'transition-opacity duration-150'])
+  wave: cva([
+    'border-foreground/30 pointer-events-none fixed top-0 left-0 z-9999 -translate-x-1/2 -translate-y-1/2 border',
+    'h-[72px] w-[72px] rounded-full opacity-0',
+    'mix-blend-exclusion'
+  ]),
+  centerPointer: cva([
+    'pointer-events-none fixed top-0 left-0 z-9999',
+    'flex items-center justify-center opacity-0',
+    'mix-blend-exclusion'
+  ]),
+  icon: cva(
+    ['text-background dark:text-foreground absolute opacity-0', 'transition-opacity duration-150'],
+    {
+      variants: {
+        offset: {
+          none: '',
+          pointer: 'translate-x-[15%] translate-y-[40%]'
+        }
+      },
+      defaultVariants: { offset: 'none' }
+    }
+  )
 }
 
 type CursorState = 'default' | 'pointer' | 'disabled' | 'text' | 'grab'
+
+type CursorProps = {
+  disablePointer?: boolean
+}
 
 const getCursorState = (el: Element | null): CursorState => {
   if (!el || el === document.documentElement) return 'default'
@@ -30,7 +54,8 @@ const getCursorState = (el: Element | null): CursorState => {
   return getCursorState(el.parentElement)
 }
 
-const LERP = 0.12
+const LERP = 0.1 // higher is faster
+const LERP_POINTER = 1
 const SCALE: Record<CursorState, number> = {
   default: 1,
   pointer: 1.25,
@@ -39,8 +64,10 @@ const SCALE: Record<CursorState, number> = {
   grab: 1.25
 }
 
-const Cursor: FC = () => {
+const Cursor: FC<CursorProps> = ({ disablePointer = false }) => {
   const ringRef = useRef<HTMLDivElement>(null)
+  const waveRef = useRef<HTMLDivElement>(null)
+  const centerPointerRef = useRef<HTMLDivElement>(null)
   const defaultRef = useRef<HTMLDivElement>(null)
   const pointerRef = useRef<HTMLDivElement>(null)
   const disabledRef = useRef<HTMLDivElement>(null)
@@ -52,6 +79,8 @@ const Cursor: FC = () => {
     if (!window.matchMedia('(pointer: fine)').matches) return
 
     const ring = ringRef.current
+    const wave = waveRef.current
+    const centerPointer = centerPointerRef.current
     const icons: Record<CursorState, HTMLDivElement | null> = {
       default: defaultRef.current,
       pointer: pointerRef.current,
@@ -59,17 +88,20 @@ const Cursor: FC = () => {
       text: textRef.current,
       grab: grabRef.current
     }
-    if (!ring || Object.values(icons).some((el) => !el)) return
+    const hasIcons = centerPointer && Object.values(icons).every(Boolean)
+    if (!ring || !wave) return
 
     let rafId: number
     let mouseX = 0
     let mouseY = 0
     let x = 0
     let y = 0
+    let px = 0
+    let py = 0
     let scale = SCALE.default
     let targetScale = SCALE.default
 
-    icons.default!.style.opacity = '1'
+    if (hasIcons) icons.default!.style.opacity = '1'
 
     const onMouseMove = (e: MouseEvent) => {
       mouseX = e.clientX
@@ -79,8 +111,10 @@ const Cursor: FC = () => {
     const onMouseOver = (e: MouseEvent) => {
       const state = getCursorState(e.target as Element)
       targetScale = SCALE[state]
-      for (const [key, el] of Object.entries(icons)) {
-        el!.style.opacity = key === state ? '1' : '0'
+      if (hasIcons) {
+        for (const [key, el] of Object.entries(icons)) {
+          el!.style.opacity = key === state ? '1' : '0'
+        }
       }
     }
 
@@ -89,39 +123,63 @@ const Cursor: FC = () => {
       y += (mouseY - y) * LERP
       scale += (targetScale - scale) * LERP
       ring.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${scale})`
+
+      if (hasIcons) {
+        px += (mouseX - px) * LERP_POINTER
+        py += (mouseY - py) * LERP_POINTER
+        centerPointer!.style.transform = `translate(${px}px, ${py}px) translate(-50%, -50%)`
+      }
+
       rafId = requestAnimationFrame(tick)
+    }
+
+    const onMouseDown = (e: MouseEvent) => {
+      wave.style.top = `${e.clientY}px`
+      wave.style.left = `${e.clientX}px`
+      wave.style.animation = 'none'
+      void wave.offsetHeight // force reflow to restart animation
+      wave.style.animation = 'var(--animate-cursor-wave)'
     }
 
     window.addEventListener('mousemove', onMouseMove, { passive: true })
     window.addEventListener('mouseover', onMouseOver, { passive: true })
+    window.addEventListener('mousedown', onMouseDown, { passive: true })
     rafId = requestAnimationFrame(tick)
     ring.style.opacity = '1'
+    if (hasIcons) centerPointer!.style.opacity = '1'
 
     return () => {
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseover', onMouseOver)
+      window.removeEventListener('mousedown', onMouseDown)
       cancelAnimationFrame(rafId)
     }
-  }, [])
+  }, [disablePointer])
 
   return (
-    <div ref={ringRef} className={cn(styles.ring())}>
-      <div ref={defaultRef} className={cn(styles.icon(), 'opacity-0')}>
-        <PlusIcon size={16} strokeWidth={1} />
-      </div>
-      <div ref={pointerRef} className={cn(styles.icon(), 'opacity-0')}>
-        <PointerIcon size={16} strokeWidth={1} />
-      </div>
-      <div ref={disabledRef} className={cn(styles.icon(), 'opacity-0')}>
-        <BanIcon size={16} strokeWidth={1} />
-      </div>
-      <div ref={textRef} className={cn(styles.icon(), 'opacity-0')}>
-        <TextCursorIcon size={16} strokeWidth={1} />
-      </div>
-      <div ref={grabRef} className={cn(styles.icon(), 'opacity-0')}>
-        <HandIcon size={16} strokeWidth={1} />
-      </div>
-    </div>
+    <>
+      <div ref={ringRef} className={cn(styles.ring())} />
+      <div ref={waveRef} className={cn(styles.wave())} />
+      {!disablePointer && (
+        <div ref={centerPointerRef} className={cn(styles.centerPointer())}>
+          <div ref={defaultRef} className={cn(styles.icon())}>
+            <PlusIcon size={16} strokeWidth={2} />
+          </div>
+          <div ref={pointerRef} className={cn(styles.icon({ offset: 'pointer' }))}>
+            <PointerIcon size={16} strokeWidth={2} />
+          </div>
+          <div ref={disabledRef} className={cn(styles.icon())}>
+            <BanIcon size={16} strokeWidth={2} />
+          </div>
+          <div ref={textRef} className={cn(styles.icon())}>
+            <TextCursorIcon size={16} strokeWidth={2} />
+          </div>
+          <div ref={grabRef} className={cn(styles.icon())}>
+            <HandIcon size={16} strokeWidth={2} />
+          </div>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/components/atoms/media.tsx
+++ b/components/atoms/media.tsx
@@ -8,7 +8,7 @@ import { cn, cva, VariantProps } from '@/utils/theme'
 
 const styles = {
   root: cva(
-    'bg-muted relative flex h-auto w-full items-center justify-center overflow-hidden rounded-xl border shadow-md'
+    'bg-muted relative flex h-auto max-h-full w-full max-w-full items-center justify-center overflow-hidden rounded-xl border'
   ),
   icon: cva('absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-15'),
   comp: cva('relative h-auto max-h-full w-full max-w-full', {

--- a/components/organisms/dialog-lightbox.tsx
+++ b/components/organisms/dialog-lightbox.tsx
@@ -29,7 +29,7 @@ const styles = {
 
   header: cva('flex w-full max-w-screen items-center justify-center gap-4 border-b p-8'),
   stage: cva('relative flex min-h-0 w-full items-center justify-center p-8'),
-  footer: cva('max-h-48 overflow-scroll border-t p-8 pb-4'),
+  footer: cva('max-h-48 overflow-y-auto border-t p-8 pb-4'),
 
   thumbnails: cva('flex gap-2 overflow-x-auto'),
   thumb: cva('w-16 shrink-0 cursor-pointer overflow-hidden opacity-50 transition-opacity', {

--- a/components/organisms/section-contact.tsx
+++ b/components/organisms/section-contact.tsx
@@ -9,6 +9,7 @@ import {
   PhoneIcon
 } from 'lucide-react'
 import { Bg } from '@/components/atoms/bg'
+import { Button } from '@/components/atoms/button'
 import { Hypertext } from '@/components/atoms/hypertext'
 import { Icon } from '@/components/atoms/icon'
 import { Section } from '@/components/molecules/section'
@@ -137,9 +138,11 @@ const SectionContact = forwardRef<SectionContactRef, SectionContactProps>((props
                 {label}
               </TableCell>
               <TableCell className={cn(styles.tableCellValue())}>
-                <Link href={href(tony)} target={external ? '_blank' : undefined}>
-                  {value}
-                </Link>
+                <Button variant="default" asChild>
+                  <Link href={href(tony)} target={external ? '_blank' : undefined}>
+                    {value}
+                  </Link>
+                </Button>
               </TableCell>
             </TableRow>
           ))}

--- a/components/sections/footer.tsx
+++ b/components/sections/footer.tsx
@@ -2,7 +2,9 @@
 
 import Link from 'next/link'
 import { FC, HTMLAttributes } from 'react'
+import { formatInTimeZone } from 'date-fns-tz'
 import { MusicIcon, PauseIcon, PlayIcon, SunMoonIcon } from 'lucide-react'
+import { appTimeZone } from '@/constants/date'
 import { useTheme } from '@/hooks/theme'
 import { useBgmContext } from '@/providers/bgm'
 import { cn, cva, type VariantProps } from '@/utils/theme'
@@ -44,15 +46,16 @@ const Footer: FC<FooterProps> = (props) => {
   const { variant, className, ...rest } = props
 
   const { isPlaying, toggle } = useBgmContext()
-  const { handleThemeModeToggle } = useTheme()
+  const { theme, handleThemeModeToggle } = useTheme()
+  const year = formatInTimeZone(new Date(), appTimeZone, 'yyyy')
 
   return (
     <footer className={cn(styles.root({ className }))} {...rest}>
       {[
-        { blur: 'backdrop-blur-[2px]', stop: '0%' },
-        { blur: 'backdrop-blur-[4px]', stop: '33%' },
-        { blur: 'backdrop-blur-[8px]', stop: '66%' },
-        { blur: 'backdrop-blur-[16px]', stop: '95%' }
+        { blur: 'backdrop-blur-[8px]', stop: '0%' },
+        { blur: 'backdrop-blur-[12px]', stop: '25%' },
+        { blur: 'backdrop-blur-[16px]', stop: '50%' },
+        { blur: 'backdrop-blur-[20px]', stop: '75%' }
       ].map(({ blur, stop }) => (
         <div
           key={stop}
@@ -64,7 +67,7 @@ const Footer: FC<FooterProps> = (props) => {
       <div className={cn(styles.container())}>
         <div className={cn(styles.bar({ variant }))}>
           <div className={cn(styles.left())}>
-            <Button size="icon" variant={isPlaying ? 'secondary' : 'ghost'} onClick={toggle}>
+            <Button variant={isPlaying ? 'secondary' : 'ghost'} onClick={toggle}>
               <Icon icon={isPlaying ? PauseIcon : PlayIcon} />
             </Button>
             <Button className={cn(styles.bgm())} size="none" variant="link" asChild>
@@ -78,8 +81,15 @@ const Footer: FC<FooterProps> = (props) => {
             </Button>
           </div>
           <div className={cn(styles.right())}>
-            <Button size="icon" variant="ghost" onClick={handleThemeModeToggle}>
+            <p className={cn(styles.bgm(), 'text-muted-foreground text-xs')}>
+              © {year} Tony Ko — AGPL
+            </p>
+            <Button
+              variant={theme === 'dark' ? 'secondary' : 'ghost'}
+              onClick={handleThemeModeToggle}
+            >
               <Icon icon={SunMoonIcon} />
+              {theme === 'light' ? 'Light' : 'Dark'}
             </Button>
           </div>
         </div>

--- a/components/sections/header.tsx
+++ b/components/sections/header.tsx
@@ -69,10 +69,10 @@ const Header: FC<HeaderProps> = (props) => {
   return (
     <header className={cn(styles.root({ className }))} {...rest}>
       {[
-        { blur: 'backdrop-blur-[2px]', stop: '0%' },
-        { blur: 'backdrop-blur-[4px]', stop: '33%' },
-        { blur: 'backdrop-blur-[8px]', stop: '66%' },
-        { blur: 'backdrop-blur-[16px]', stop: '95%' }
+        { blur: 'backdrop-blur-[8px]', stop: '0%' },
+        { blur: 'backdrop-blur-[12px]', stop: '25%' },
+        { blur: 'backdrop-blur-[16px]', stop: '50%' },
+        { blur: 'backdrop-blur-[20px]', stop: '75%' }
       ].map(({ blur, stop }) => (
         <div
           key={stop}

--- a/themes/theme.css
+++ b/themes/theme.css
@@ -159,6 +159,7 @@
 	--animate-slide-up: slide-up 1.5s ease-out;
 	--animate-fade-in: fade-in 1.5s ease-out;
 	--animate-fade-out: fade-out 1.5s ease-out;
+	--animate-cursor-wave: cursor-wave 0.6s ease-out forwards;
 }
 
 @keyframes accordion-down {
@@ -220,5 +221,16 @@
 	100% {
 		transform: translateY(0);
 		opacity: 1;
+	}
+}
+
+@keyframes cursor-wave {
+	from {
+		scale: 0;
+		opacity: 0.6;
+	}
+	to {
+		scale: 4;
+		opacity: 0;
 	}
 }


### PR DESCRIPTION
## Summary

- **Cursor**: wave click effect, center pointer with instant LERP, mix-blend-mode exclusion fill, `disablePointer` prop, pointer icon hotspot aligned to SVG fingertip tip, semantic color tokens throughout
- **Footer**: dynamic copyright year (Toronto timezone), AGPL license notice, theme toggle with Light/Dark label and state-aware variant
- **Contact**: table value links use `<Button variant="default" asChild>` for consistent styling
- **Media / Lightbox / Header**: max sizing on media atom, `overflow-y-auto` on lightbox footer, stronger backdrop blur on header and footer layers

## Test plan

- [ ] Verify cursor ring lags while center icons snap directly to pointer
- [ ] Click anywhere — confirm wave expands and fades from click point
- [ ] Toggle `disablePointer` prop — ring should still track, icons hidden
- [ ] Check pointer icon hotspot aligns with fingertip in both light/dark mode
- [ ] Footer shows correct year and AGPL notice next to theme toggle
- [ ] Theme toggle label reflects current mode; secondary variant active in dark mode
- [ ] Contact table links render as buttons and navigate correctly
- [ ] Media fits container without overflow; lightbox footer scrolls vertically only