### PR TITLE
fix(home): remove grayscale desaturation from intro avatar

### DIFF
--- a/components/organisms/section-home.tsx
+++ b/components/organisms/section-home.tsx
@@ -48,7 +48,7 @@ const styles = {
   avatar: cva([
     'h-auto w-[50%]',
     'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-    'transition-all duration-1000 hover:scale-105 hover:grayscale'
+    'transition-all duration-1000 hover:scale-105'
   ]),
 
   cta: cva('mt-2')

--- a/components/organisms/section-home.tsx
+++ b/components/organisms/section-home.tsx
@@ -48,7 +48,7 @@ const styles = {
   avatar: cva([
     'h-auto w-[50%]',
     'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-    'grayscale-25 transition-all duration-1000 hover:scale-105 hover:grayscale'
+    'transition-all duration-1000 hover:scale-105 hover:grayscale'
   ]),
 
   cta: cva('mt-2')


### PR DESCRIPTION
## Summary
- Removes `grayscale-25` default desaturation from the intro avatar image
- Removes `hover:grayscale` hover desaturation from the intro avatar image